### PR TITLE
Add event parameter to closeBox

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -285,11 +285,11 @@ var AutoComplete = (function () {
         return request;
     }
 
-    function closeBox(result, closeNow) {
+    function closeBox(result, event, closeNow) {
         if (closeNow) {
             attrClass(result, "autocomplete");
         } else {
-            setTimeout(function() {closeBox(result, true);}, 150);
+            setTimeout(function() {closeBox(result, event, true);}, 150);
         }
     }
 


### PR DESCRIPTION
Incorrect arity for onblur event leads to `closeNow` is always positive and no item click events was fired 