### PR TITLE
Fixed issue with removing 'ul' on mobile browsers (exception was thrown)

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -335,7 +335,7 @@ class AutoComplete {
             }
     
             if (this.DOMResults.hasChildNodes()) {
-                this.DOMResults.childNodes[0].remove();
+		this.DOMResults.removeChild(this.DOMResults.childNodes[0]);
             }
             
             this.DOMResults.appendChild(ul);


### PR DESCRIPTION
There was a bug when user typed second or next character in autocomplete input on mobile browsers. 