### PR TITLE
now URI encodes query parameters

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -605,7 +605,7 @@ class AutoComplete {
             method: string = params._HttpMethod(),
             url: string = params._Url(),
             queryParams: string = params._Pre(),
-            queryParamsStringify: string = params._QueryArg() + "=" + queryParams;
+            queryParamsStringify: string = encodeURIComponent(params._QueryArg()) + "=" + encodeURIComponent(queryParams);
 
         if (method.match(/^GET$/i)) {
             if (url.indexOf("?") !== -1) {


### PR DESCRIPTION
If you have query data that contains URi escapes (such as +) then you get corrupted data back to your query.  You can simply use POST rather than GET to get around this, but this fixes the issue.

I didn't rebuild the dist directory as I don't have an environment for it, however I am running the patched version on my own site with no issues.